### PR TITLE
I have a schema that has <xsd:element name="Size" type="xsd:long"/>

### DIFF
--- a/src/erlsom_write.erl
+++ b/src/erlsom_write.erl
@@ -97,13 +97,13 @@ struct2xml(Struct,
           end,
           ResultForThisElement = printNilValue(Alternatives, AttrValues, Model, Namespaces, DeclaredNamespaces);
         [V1 | _] ->
-          case V1 of  
-            _ when is_integer(V1) -> %% CurrentValue is a string
-              ResultForThisElement = printValue(CurrentValue, Alternatives, Namespaces, DeclaredNamespaces, Mixed);
-            _ when is_tuple(V1) -> 
+          case V1 of
+            _ when is_tuple(V1) ->
               %% debug("alternative with MaxOccurs > 1"),
               ResultForThisElement = processAlternatives(CurrentValue, Alternatives, Model, DeclaredNamespaces, Th,
-                                                         Mixed)
+                                                         Mixed);
+            _ ->
+              ResultForThisElement = printValue(CurrentValue, Alternatives, Namespaces, DeclaredNamespaces, Mixed)
           end;
         #qname{} ->
           ResultForThisElement = printValue(CurrentValue, Alternatives, Namespaces, DeclaredNamespaces, Mixed);


### PR DESCRIPTION
& erlsom_write wont write a string or an integer for it unless I use this patch
original schema: http://doc.s3.amazonaws.com/2006-03-01/AmazonS3.xsd
