### PR TITLE
Fix compile warnings

### DIFF
--- a/src/erlsom_compile.erl
+++ b/src/erlsom_compile.erl
@@ -366,8 +366,8 @@ replaceElements(ImportedTypes, [Original = #typeInfo{} | Tail],
 %% information from this schema is combined with info from a potential 'parent' XSD. 
 combineInfo(#schemaType{targetNamespace=Tns, elementFormDefault=Efd, 
                         attributeFormDefault = Afd}, 
-            Acc = #p1acc{tns=TnsParent, efd = EfdParent, 
-                         afd = AfdParent, nss = Namespaces},
+            Acc = #p1acc{tns=TnsParent, efd = _EfdParent,
+                         afd = _AfdParent, nss = Namespaces},
             Prefix) ->
    Acc#p1acc{tns = if 
                       Tns == undefined -> TnsParent; 
@@ -776,7 +776,7 @@ translateAlternative(#localElementType{name=Name, type=Type, ref=undefined, simp
 %% -record(groupRefType, {ref, minOccurs, maxOccurs}).
 translateAlternative(#groupRefType{ref=Ref, minOccurs=Min, maxOccurs=Max}, Acc = #p1acc{nss = Nss}) ->
   {#alternative{tag="##TODO", type=erlsom_lib:makeGroupRef(Ref, Nss), real=false, min=minMax(Min), max=minMax(Max)}, Acc};
-translateAlternative(#anyType{minOccurs=Min, maxOccurs = Max, namespace = Ns, processContents = Pc}, Acc) ->
+translateAlternative(#anyType{minOccurs=_Min, maxOccurs = _Max, namespace = Ns, processContents = Pc}, Acc) ->
    AnyInfo = #anyInfo{prCont = case Pc of undefined -> "strict"; _ -> Pc end, 
                      ns = case Ns of undefined -> "##any"; _ -> Ns end}, 
   {#alternative{tag="#any", type="any", real=true, anyInfo = AnyInfo}, Acc};


### PR DESCRIPTION
Fix 4 compile warnings.

```
$ make
==> erlsom (compile)
Compiled src/erlsom_add.erl
Compiled src/erlsom.erl
src/erlsom_compile.erl:369: Warning: variable 'EfdParent' is unused
src/erlsom_compile.erl:370: Warning: variable 'AfdParent' is unused
src/erlsom_compile.erl:779: Warning: variable 'Max' is unused
src/erlsom_compile.erl:779: Warning: variable 'Min' is unused
Compiled src/erlsom_compile.erl
```
