### PR TITLE
fix xsd model (annotation tag can be a child of attributeGroup ref tag)

### DIFF
--- a/src/erlsom_parseXsd.erl
+++ b/src/erlsom_parseXsd.erl
@@ -586,7 +586,10 @@ xsdModel(Namespaces) ->
 %% -record(attributeGroupRefType, {ref}).
        #type{nm = attributeGroupRefType, 
              anyAttr = AnyAttr,
-	     els = [],
+	     els = [#el{alts = [#alt{tag = 'xsd:annotation', tp = 'annotationType'}],
+                        mn = 0,
+                        mx = 1,
+                        nr = 2}],
 	     atts = [#att{nm = ref, nr = 1, opt = true, tp = qname}, 
 	             #att{nm = id, nr = 2, opt = true, tp = char}],
              nr = 3}], 


### PR DESCRIPTION
As defined in http://www.w3.org/TR/xmlschema-1/#declare-type (3.4.2)

Fixes issue #30 