### PR TITLE
Add warning/note concerning duplicate XSD inclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,12 @@ It shows how "nil" values are represented - note that there are 2 different case
 
 Example 9 also shows what happens to "any-attributes" ("issued", in this case): these are put into the first field of the record.
 
+*A note about schema inclusion*
+
+Be careful when working with complex schemas since Erlsom does not handle duplicate inclusions. You may end up with duplicate types!
+
+However, duplicate inclusions can be resolved, e.g. by either editing the schemas or by detecting duplicate includes in a custom `include_fun` (which should then return an empty schema).
+
 ## <a name="installation">Installation</a>
 The easiest way to install Erlsom is probably to use rebar. 
  


### PR DESCRIPTION
A small documentation enhancement about duplicate schema inclusions.

For the RFC mentioned in issue #34 I ended up using the custom `include_fun` below. This fun assumes that all referenced XSDs have been downloaded into one of the folders provided as `include_dirs`. It uses the caller's process dictionary to find out whether a certain XSD schema has been included already.

```erlang
%%------------------------------------------------------------------------------
%% @doc
%% This function should be used as `include_fun' option for
%% {@link erlsom:compile_xsd_file/2} and {@link erlsom:write_xsd_hrl_file/3}.
%% @end
%%------------------------------------------------------------------------------
find_xsd(Namespace, URL = "http://" ++ _, _IncludeFiles, IncludeDirs) ->
    {ok, {_, _, _, _, Path, _}} = http_uri:parse(URL),
    File = filename:basename(Path),
    {get_file(File, IncludeDirs), external_prefix(Namespace)};
find_xsd(undefined, Location, _IncludeFiles, IncludeDirs) ->
    {get_file(Location, IncludeDirs), undefined}.

get_file(File, [Dir | Rest]) ->
    Path = filename:join([Dir, File]),
    case {filelib:is_file(Path), get(File)} of
        {true, undefined}  ->
            put(File, File),
            read_file(Path);
        {true, File} ->
            io:format("Skipping duplicate include ~p~n", [File]),
            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\""
                "  elementFormDefault=\"qualified\""
                "  attributeFormDefault=\"unqualified\" />";
        {false, _} ->
            get_file(File, Rest)
    end.

read_file(Path) ->
    {ok, Binary} = file:read_file(Path),
    erlsom_lib:toUnicode(Binary).

external_prefix(undefined) ->
    undefined;
external_prefix(Namespace) ->
    string:substr(lists:last(string:tokens(Namespace, "/ ")), 1, 5).
```