### PR TITLE
Add "Restriction of a choice" to XSD parsing.

### DIFF
--- a/src/erlsom_parseXsd.erl
+++ b/src/erlsom_parseXsd.erl
@@ -379,6 +379,7 @@ xsdModel(Namespaces) ->
                         mx = 1, 
                         nr = 2},
                     #el{alts = [#alt{tag = 'xsd:sequence', tp = 'sequenceType'}, 
+                                #alt{tag = 'xsd:choice', tp = 'choiceType'},
                                 #alt{tag = 'xsd:group', tp = 'groupRefType'}],
                         mn = 0, 
                         mx = 1, 


### PR DESCRIPTION
Allow Erlsom to parse "Restriction of a choice" in XSD.
E.g. (this isn't sensible, just note the `restriction` `choice` pattern)
```xml
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" >

  <xsd:element name="root" type="BBB"/>

  <xsd:complexType name="AAA">
    <xsd:choice>
      <xsd:element name="x" type="xsd:string"/>
    </xsd:choice>
  </xsd:complexType>

  <xsd:complexType name="BBB">
    <xsd:complexContent>
      <xsd:restriction base="AAA">
        <xsd:choice>
          <xsd:element name="x" type="xsd:string"/>
        </xsd:choice>
      </xsd:restriction>
    </xsd:complexContent>
  </xsd:complexType>

</xsd:schema>
```