### PR TITLE
treat US-ASCII encoding as Latin1

### DIFF
--- a/src/erlsom_lib.erl
+++ b/src/erlsom_lib.erl
@@ -635,6 +635,8 @@ detect_encoding3(Variables) ->
           iso_8859_1;
         'iso-8859-15' -> 
           iso_8859_15;
+        'us-ascii' -> 
+          iso_8859_1;
         _ -> throw({error, "Encoding " ++ Encoding ++ " not supported"})
       end;
     _ -> 
@@ -653,6 +655,7 @@ encoding_type(Cs) when is_list(Cs) ->
        "iso8859-15"  -> 'iso-8859-15';
        "utf-8"      -> 'utf-8';
        "utf_8"      -> 'utf-8';
+       "us-ascii"   -> 'us-ascii';
        _            -> false 
    end.
 


### PR DESCRIPTION
Some document authors make a point about the document being limited to 7-bit charactes, i.e. plain ASCII. (This could help with non-8-bit-clean system or byte-wise parsing.) E.g. see `urn:oasis:names:tc:SAML:2.0:assertion` at http://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd
This addition will treat the `US-ASCII` encoding as Latin1, which it is a subset of.