### PR TITLE
suppress prefix on local types when unqualified is requested

### DIFF
--- a/src/erlsom_compile.erl
+++ b/src/erlsom_compile.erl
@@ -595,6 +595,12 @@ translateAttribute(GroupRef = #attributeGroupRefType{}, _Acc) ->
 %% returns {#typeInfo{}, #p1acc{}}
 translateComplexTypeModel(undefined, Acc) ->
   {#typeInfo{elements = [], seqOrAll = sequence}, Acc};
+% do not use a prefix on local types when unqualified is requested.
+% maybe this logic needs to be pulled up into transformTypes?
+translateComplexTypeModel(Model, Acc = #p1acc{efd="unqualified", nsp=Nsp})
+   when Nsp /= "" ->
+  {Model2, Acc2} = translateComplexTypeModel(Model, Acc#p1acc{nsp = ""}),
+  {Model2, Acc2#p1acc{nsp = Nsp}};
 translateComplexTypeModel(Sequence = #sequenceType{elements=Elements, minOccurs=Min, maxOccurs=Max},
                             %% Acc = #p1acc{seqCnt = Count, nsp = Prefix, path = Path, efd = Efd}) ->
                             Acc = #p1acc{seqCnt = Count, path = Path}) ->


### PR DESCRIPTION
Schema documents that set an `elementFormDefault` of `unqualified` need local types to be unqualified, i.e. unprefixed.
E.g. in http://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd the `AuthnStatementType` will be `p:AuthnStatementType` but the contained sequence needs to be `AuthnStatementType/SEQ1`, otherwise `pass4` will fail to replace `##TODO` entries.