### PR TITLE
when translating types with extends consider the restricts on base types

### DIFF
--- a/src/erlsom_pass2.erl
+++ b/src/erlsom_pass2.erl
@@ -219,7 +219,7 @@ translateType(Type = #typeInfo{elements=Elemts, attributes=Attrs, extends = Base
               Types, Info = #schemaInfo{namespaces=NS})
   when Base /= undefined ->
   case erlsom_lib:searchBase(erlsom_lib:makeTypeRef(Base, NS), Types) of
-    {value, #typeInfo{elements = BaseEls, attributes = BaseAttrs, anyAttr = BaseAnyAttr, extends = Base2, mixed = Mixed2}} ->
+    {value, #typeInfo{elements = BaseEls, attributes = BaseAttrs, anyAttr = BaseAnyAttr, extends = Base2, restricts = Base3, mixed = Mixed2}} ->
       %% debug(Elemts),
       %% debug(BaseEls),
       %% debug(Attrs),
@@ -229,7 +229,7 @@ translateType(Type = #typeInfo{elements=Elemts, attributes=Attrs, extends = Base
                                   attributes = BaseAttrs ++ Attrs,  
 				  anyAttr = NewAnyAttr,
                                   mixed = case Mixed of undefined -> Mixed2; _ -> Mixed end,
-                                  extends = Base2}, Types, Info);
+                                  extends = Base2, restricts = Base3}, Types, Info);
     _Else ->
       throw({error, "Base type not found: " ++ erlsom_lib:makeTypeRef(Base, NS)})
   end;


### PR DESCRIPTION
When a type `extends` some base, that in turn `restricts`, that last base information is lost.
Consider
```xml
    <complexType name="MyBaseBaseType">
        <sequence>
            <element name="Result" type="string" />
        </sequence>
        <attribute name="RequestID" type="string" use="optional" />
    </complexType>

    <complexType name="MyBaseType">
        <complexContent>
            <restriction base="tns:MyBaseBaseType">
                <sequence>
                    <element name="Result" maxOccurs="1" minOccurs="0" />
                </sequence>
            </restriction>
        </complexContent>
    </complexType>

    <element name="MyType">
        <complexType>
            <complexContent>
                <extension base="tns:MyBaseType">
                    <sequence>
                        <element name="ResponseDataSequence" type="string" maxOccurs="1" minOccurs="0" />
                    </sequence>
                </extension>
            </complexContent>
        </complexType>
    </element>
```