### PR TITLE
fix docs: include_files is actually {Namespace, Prefix, Location}

### DIFF
--- a/src/erlsom.erl
+++ b/src/erlsom.erl
@@ -81,7 +81,7 @@
 %%     'Include_dirs' is a list of directories (strings), separated by comma's. 
 %%       It defaults to ["."].
 %%           
-%%     'Include_files' is a list of tuples {Namespace, Location, Prefix}. 
+%%     'Include_files' is a list of tuples {Namespace, Prefix, Location}. 
 %%
 %% Behaviour for includes:
 %% 

--- a/src/erlsom_compile.erl
+++ b/src/erlsom_compile.erl
@@ -73,7 +73,7 @@
                 nss,            %% namespaces ([#namespace{}])
                 includeFun,     %% function to find included XSDs
                 includeDirs,    %% directories to look for XSDs
-	        includeFiles,   %% tuples {Namespace, Location, Prefix}
+                includeFiles,   %% tuples {Namespace, Prefix, Location}
                                 %% or {Namespace, Schema, Prefix}, where 
                                 %% Schema is a parsed XSD (used to parse WSDLs
                                 %% with multiple XSDs).
@@ -156,7 +156,7 @@ compile_internal(Xsd, Options, Parsed) ->
                 end,
   IncludeFiles = case lists:keysearch('include_files', 1, Options) of
                    {value, {_, Files}} -> Files;
-                   _ -> Namespaces %% the two options are mutually exlclusive
+                   _ -> Namespaces %% the two options are mutually exclusive
                  end,
   put(erlsom_typePrefix, TypePrefix),
   put(erlsom_groupPrefix, GroupPrefix),


### PR DESCRIPTION
There is a typo in the documentation for `include_files`. It's actually a list of `{Namespace, Prefix, Location}` tuples. See `findFile/4` https://github.com/willemdj/erlsom/blob/master/src/erlsom_lib.erl#L722