### PR TITLE
Transform the parser to CPS.  Support pull parsing

### DIFF
--- a/src/erlsom.erl
+++ b/src/erlsom.erl
@@ -36,6 +36,7 @@
          scan/2, scan/3, scan_file/2, scan_file/3,
          write/2,
          parse_sax/3, parse_sax/4,
+         parse_pull/2,
          sax/3, sax/4,
          write_hrl/2, 
 	 write_xsd_hrl_file/2, write_xsd_hrl_file/3, 
@@ -356,6 +357,10 @@ parse_sax(Xml, State, EventFun, Options) ->
 parse_sax(Xml, State, EventFun) ->
   parse_sax(Xml, State, EventFun, []).
 
+
+
+parse_pull(Xml, Options) ->
+    parse_sax(Xml, [], fun(Ev, Accum) -> [Ev | Accum] end, [pull | Options]).
 %%----------------------------------------------------------------------
 %% Function: sax/3
 %%

--- a/src/erlsom_sax.erl
+++ b/src/erlsom_sax.erl
@@ -179,12 +179,14 @@ getOptions(Options) ->
   getOptions(Options, #erlsom_sax_state{}).
 
 getOptions([], S) ->
-  case S#erlsom_sax_state.continuation_fun of
-    undefined -> 
+  case {S#erlsom_sax_state.continuation_fun, S#erlsom_sax_state.is_pull} of
+     {undefined, false} -> 
       S#erlsom_sax_state{continuation_fun = fun(T, St) -> {T, St} end};
-    _ -> 
+    _ ->
       S
   end;
+getOptions([pull | T], S) ->
+  getOptions(T, S#erlsom_sax_state{is_pull = true});
 getOptions([expand_entities | T], S) ->
   getOptions(T, S#erlsom_sax_state{expand_entities = true});
 getOptions([{expand_entities, V} | T], S) when is_boolean(V) ->

--- a/src/erlsom_sax.hrl
+++ b/src/erlsom_sax.hrl
@@ -52,6 +52,7 @@
                              %% expanded entities together.
    entity_size_acc = 0, %% accumulated size of entities
    continuation_fun,
+   is_pull = false,
    %% entity_relations is used to check on circular definitions
    entity_relations = []}).
 


### PR DESCRIPTION
I wonder if you will be willing to merge something in the lines of this patch.
(In such case this will need more tests and performance comparison)

The basic idea is:
* Backward compatible,  actual api is unchanged
* Provide new, small api for allowing pull-parsing  (erlsom:parse_pull/2).
* Both use the same underling parsing code

For pull parsing, I mean:
```
3> {continue, C1, E1} = erlsom:parse_pull(<<"<s:xstream xmlns:s='http://some-namespace.com' as='234' version='1.0'>">>, [{output_encoding, utf8}]).
{continue,#Fun<erlsom_sax_lib.4.36439255>,
          [startDocument,
           {startPrefixMapping,"s","http://some-namespace.com"},
           {startElement,"http://some-namespace.com","xstream","s",
                         [{attribute,"version",[],[],<<"1.0">>},
                          {attribute,"as",[],[],<<"234">>}]}]}
4> {continue, C2, E2} = C1(<<"<a href='ab">>).
{continue,#Fun<erlsom_sax_lib.0.36439255>,[]}
5> {continue, C3, E3} = C2(<<"c'><b>ss</b></a>">>).
{continue,#Fun<erlsom_sax_lib.4.36439255>,
          [{startElement,[],"a",[],
                         [{attribute,"href",[],[],<<"abc">>}]},
           {startElement,[],"b",[],[]},
           {characters,<<"ss">>},
           {endElement,[],"b",[]},
           {endElement,[],"a",[]}]}
6> {ok, E4, _Rest} = C3(<<"</s:xstream> tail data">>).   
{ok,[{endElement,"http://some-namespace.com","xstream","s"},
     {endPrefixMapping,"s"},
     endDocument],
    " tail data"}
```
That is, allow the user of the parser to  pass the data in chunks to the parser, instead of the parser asking for more in a callback.

This allow simpler integration for long running parsing (think in infinite xml streams coming from network), and also allows hibernating the parsing process,  that on current version is not always possible (as hibernate discard the stack).

Returning the list of events instead of using sax callbacks is mostly a matter of preference,  sax callbacks can still be used. I found returning a list easier to work with (and size of the list is bounded
if you feed the parser in chunks).

The change was to make every possible "blocking" parsing operation be in continuation passing style. Then the continueFun/* in  erlsom_sax_lib check if we are in a pull parsing or not.  If we are a pull parser, instead of asking the user for more data, it just return a function from where caller can continue parsing:
```
continueFun2K(T, V1, V2, V3, State = #erlsom_sax_state{continuation_fun=undefined}, ParseFun, K) ->
    {continue, fun(Data) -> ParseFun(<<T/binary, Data/binary>>, V1, V2,
    V3, State#erlsom_sax_state{user_state = []}, K) end,
         lists:reverse(State#erlsom_sax_state.user_state)};
```
(when pull parsing,  the sax callbacks  just accumulate the events in  the user_state, so here we return them on the right order)

For transforming to CPS, the code is now allocating more funs while parsing.  Initial test show little performance degradation, and any work done by the user with the parser events would make the difference in parsing costs irrelevant, but need more complete tests to assert that.

I only tested the utf8 backend,  others should work the same.


What's your opinion?

