### PR TITLE
make it work for schemas from www.w3.org

### DIFF
--- a/src/erlsom_lib.erl
+++ b/src/erlsom_lib.erl
@@ -828,8 +828,21 @@ findFile(Namespace, Location, IncludeFiles, IncludeDirs) ->
       {getFile(Location, IncludeDirs), undefined}
   end.
 
+getFile("http://"++_ = URL, _) ->
+  httpGetFile(URL);
 getFile("https://"++_ = URL, _) ->
-	case httpc:request(URL) of
+  httpGetFile(URL);
+getFile(Location, IncludeDirs) ->
+  case filelib:is_file(Location) of
+    true ->
+      readImportFile(Location);
+    _ ->
+      %% debug(IncludeDirs),
+      findFileInDirs(Location, IncludeDirs)
+  end.
+
+httpGetFile(URL) ->
+  case httpc:request(get, {URL, [{"user-agent", "erlsom"}]}, [], []) of
 		{ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
 			toUnicode(Body);
 		{ok,{{_HTTP,RC,Emsg}, _Headers, _Body}} ->
@@ -840,17 +853,7 @@ getFile("https://"++_ = URL, _) ->
 			error_logger:error_msg("~p: http-request failed: ~p~n",
 				[?MODULE, Reason]),
 			{error, "failed to retrieve: "++URL}
-	end;
-getFile(Location, IncludeDirs) -> 
-  case filelib:is_file(Location) of
-    true -> 
-      readImportFile(Location);
-    _ -> 
-      %% debug(IncludeDirs),
-      findFileInDirs(Location, IncludeDirs)
   end.
-
-
 
 findFileInDirs(undefined, []) ->
   throw({error, "Include file not found (undefined)"});


### PR DESCRIPTION
Trying to use erlsom with [this schema](https://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd), I noticed that it doesn't support getting a schema using `http://`.

Adding a clause for `http://` I then found that [this schema](http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd) (referenced from the first one) makes it choke because the server returns HTTP 500.

Reproducing the request of `httpc:request()` with curl:

```interactive
$ curl -v http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd -H "content-length: 0" -H "te;" -H "connection: keep-alive" -H "host: www.w3.org" -H "user-agent:"
*   Trying 128.30.52.100...
* Connected to www.w3.org (128.30.52.100) port 80 (#0)
> GET /TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd HTTP/1.1
> host: www.w3.org
> Accept: */*
> content-length: 0
> te:
> connection: keep-alive
>
* HTTP 1.0, assume close after body
< HTTP/1.0 500 Server Error
< Cache-Control: no-cache
< Connection: close
< Content-Type: text/html
<
<html><body><h1>500 Server Error</h1>
An internal server error occured.
</body></html>
* Closing connection 0
$
```

The relevant bit seems to be the missing user agent. I've thus added a user agent to the request issued by `erlsom_lib:getFile/2`.

It might seem weird to add this special measure just for _one server out there_, but it's W3C, they do host many XSDs...