### PR TITLE
Writing XML with abstract types fixed

### DIFF
--- a/priv/xsi_type/base.xsd
+++ b/priv/xsi_type/base.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    targetNamespace="urn:erlsom/xsi_type/base" elementFormDefault="qualified"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="urn:erlsom/xsi_type/base">
+    <xsd:element name="data" type="tns:BaseType"/>
+    <xsd:complexType name="BaseType">
+        <xsd:sequence>
+            <xsd:element name="base_info" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/priv/xsi_type/ext.xml
+++ b/priv/xsi_type/ext.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<base:data
+    xmlns:base="urn:erlsom/xsi_type/base"
+    xmlns:ext="urn:erlsom/xsi_type/ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:type="ext:ExtType">
+    <base:base_info>a</base:base_info>
+    <ext:ext_info>b</ext:ext_info>
+</base:data>

--- a/priv/xsi_type/ext.xsd
+++ b/priv/xsi_type/ext.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:base="urn:erlsom/xsi_type/base"
+    elementFormDefault="qualified"
+    targetNamespace="urn:erlsom/xsi_type/ext">
+    <xsd:import namespace="urn:erlsom/xsi_type/base" schemaLocation="base.xsd"/>
+    <xsd:complexType name="ExtType">
+        <xsd:complexContent>
+            <xsd:extension base="base:BaseType">
+                <xsd:sequence>
+                    <xsd:element name="ext_info" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/src/erlsom_write.erl
+++ b/src/erlsom_write.erl
@@ -329,9 +329,11 @@ processAlternativeValue(Value, Count,
       {AnyAttrPlusXsiTypeString, DeclaredNamespaces3} = 
         case Abstract of 
           false -> {AnyAttributesString, DeclaredNamespaces2};
-          _ -> 
+          _ ->
+            NameAsText = atom_to_list(Name),
+            {NamespacesStringAbs, DeclaredNamespacesAbs, _ExtraPrefixAbs} = processNamespaces(NameAsText, Namespaces, DeclaredNamespaces2),
             XsiType = [" xsi:type=\"", atom_to_list(Name), "\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""], 
-            {[AnyAttributesString, XsiType], DeclaredNamespaces2}
+            {[AnyAttributesString, XsiType, NamespacesStringAbs], DeclaredNamespacesAbs}
      end,
 
       %% deal with namespaces (that is, see if they have to be declared here)
@@ -507,13 +509,15 @@ processAnyAttributes([{{Name, Uri}, Value} | Tail], Acc, Namespaces, DeclaredNam
       processAnyAttributes(Tail, [Acc, " ", Name, "=\"", decodeIfRequired(Value), "\""], 
         Namespaces, DeclaredNamespaces);
     _Other ->
-      %% the "xsi:nil=true" is not written, because it is inserted in another way.
+      %% the "xsi:nil=true" and xsi:type are not written, because they are inserted in another way.
       case {Name, Uri, Value} of
         {"nil", "http://www.w3.org/2001/XMLSchema-instance", "true"} ->
           processAnyAttributes(Tail, Acc, Namespaces, DeclaredNamespaces);
         {"nil", "http://www.w3.org/2001/XMLSchema-instance", "1"} ->
           processAnyAttributes(Tail, Acc, Namespaces, DeclaredNamespaces);
-        _ -> 
+        {"type", "http://www.w3.org/2001/XMLSchema-instance", _} ->
+          processAnyAttributes(Tail, Acc, Namespaces, DeclaredNamespaces);
+        _ ->
           %% get prefix +, if relevant, NS declaration text
           {PrefixedName, DeclaredNamespaces2} = processAnyNamespaces(Name, Uri, Namespaces, DeclaredNamespaces),
           processAnyAttributes(Tail, [Acc, " ", PrefixedName, "=\"", decodeIfRequired(Value), "\""], 


### PR DESCRIPTION
1. Namespace used in the xsi:type was left
   not declared.
2. xsi:type from the anyAttribs was interferring
   with the handling of abstract elements.