### PR TITLE
Use actual type name, instead of nm key, for derived type checks.

### DIFF
--- a/src/erlsom_lib.erl
+++ b/src/erlsom_lib.erl
@@ -585,7 +585,7 @@ findType(TypeReference, Types, Attributes, TypeHierarchy, Namespaces, NamespaceM
     {value, Value} ->
       case findXsiType(Attributes) of
         {value, XsiType} ->
-          findDerivedType(TypeReference, XsiType, Types, TypeHierarchy, Namespaces, NamespaceMapping);
+          findDerivedType(Value#type.typeName, XsiType, Types, TypeHierarchy, Namespaces, NamespaceMapping);
         _ -> Value
       end;
     _Else ->


### PR DESCRIPTION
Otherwise, it fails when we're checking against an alias type, e.g. a sub-element that has a type assigned in the schema.