### PR TITLE
Use a fake group type for disambiguating between alternatives, similar to what is done for simple types in alts.

### DIFF
--- a/src/erlsom_lib.erl
+++ b/src/erlsom_lib.erl
@@ -40,7 +40,7 @@
          xmlString/1,
          strip/1,
          toUnicode/1, detect_encoding/1, detectEncoding/3,
-         findFile/4, find_xsd/4, findType/6,
+         findFile/4, find_xsd/4, findType/6, findType/2,
          readImportFile/1,
          newTree/0, addTreeElement/3, isAncestor/3, getAncestor/2,
          getLeaves/2,
@@ -581,13 +581,15 @@ toUnicode(Bin) ->
   autodetect(Bin).
 
 findType(TypeReference, Types, Attributes, TypeHierarchy, Namespaces, NamespaceMapping) ->
+    case findXsiType(Attributes) of
+      {value, XsiType} ->
+        findDerivedType(TypeReference, XsiType, Types, TypeHierarchy, Namespaces, NamespaceMapping);
+      _ -> findType(TypeReference, Types)
+    end.
+
+findType(TypeReference, Types) ->
   case lists:keysearch(TypeReference, #type.nm, Types) of
-    {value, Value} ->
-      case findXsiType(Attributes) of
-        {value, XsiType} ->
-          findDerivedType(TypeReference, XsiType, Types, TypeHierarchy, Namespaces, NamespaceMapping);
-        _ -> Value
-      end;
+    {value, Value} -> Value;
     _Else ->
       throw({error, "Type not found: " ++ atom_to_list(TypeReference)})
   end.

--- a/src/erlsom_pass2.erl
+++ b/src/erlsom_pass2.erl
@@ -517,7 +517,7 @@ pass3Alternatives([Alternative | Tail], TypeName, Acc, NewTypes, Optional, Alter
 pass3Alternatives([], _TypeName, Acc, NewTypes, Optional, _Alternatives, _Types, _Mixed, _Info) ->
   {Acc, NewTypes, Optional}.
 
-pass3Alternative(Alternative = #alt{tag = Name, rl = Real, tp = Type, mn = Mn}, TypeName, Alternatives, Types, _Mixed, Info) ->
+pass3Alternative(Alternative = #alt{tag = Name, rl = Real, tp = Type, mn = Mn}, TypeName, Alternatives, _Types, _Mixed, Info) ->
   Pos = case Info#schemaInfo.include_any_attrs of true -> 3; _ -> 2 end,
   if
     Real == false ->
@@ -551,15 +551,11 @@ pass3Alternative(Alternative = #alt{tag = Name, rl = Real, tp = Type, mn = Mn}, 
                 Name == '#any' -> {Alternative, []};
                 true ->
                   NewTypeName =
-                    list_to_atom(atom_to_list(TypeName) ++ "-" ++ erlsom_lib:nameWithoutPrefix(atom_to_list(Name))),
-                  case lists:keysearch(Type, #type.nm, Types) of
-                    {value, Record} ->
-                      {Alternative#alt{tp = NewTypeName, rl = true, mn = case Mn of 0 -> 0; _ -> 1 end},
-                        [Record#type{nm = NewTypeName}]};
-                    _Else ->
-                      %% debugTypes(Types),
-                      throw({error, "Type definition not found " ++ atom_to_list(Type)})
-                  end
+                    list_to_atom(atom_to_list(TypeName) ++ "_" ++ erlsom_lib:nameWithoutPrefix(atom_to_list(Name))),
+		  NewAlternative = Alternative#alt{tp = NewTypeName, rl = false, mn = case Mn of 0 -> 0; _ -> 1 end},
+		  NewElement = #el{alts = [Alternative], mn = 1, mx = 1, nr = Pos},
+		  NewTypeDef = #type{nm = NewTypeName, tp = sequence, els = [NewElement], atts = [], nr = 2},
+		  {NewAlternative, [NewTypeDef]}
               end;
             _ ->
               {Alternative, []}


### PR DESCRIPTION
Also necessitates small changes in the parser to be able to handle
top-level fake types.

COMPATIBILITY BREAKING!

Closes #76 .