### PR TITLE
Silence warnings and prepare for OTP26

### DIFF
--- a/src/erlsom_sax_latin1.erl
+++ b/src/erlsom_sax_latin1.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_sax_latin9.erl
+++ b/src/erlsom_sax_latin9.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_sax_list.erl
+++ b/src/erlsom_sax_list.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_sax_utf16be.erl
+++ b/src/erlsom_sax_utf16be.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_sax_utf16le.erl
+++ b/src/erlsom_sax_utf16le.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_sax_utf8.erl
+++ b/src/erlsom_sax_utf8.erl
@@ -1058,7 +1058,7 @@ translateReference(Reference, Context, Tail, State) ->
       %% unfortunately this function accepts illegal values
       %% to do: replace by something that throws an error in case of
       %% an illegal value
-      {[httpd_util:hexlist_to_integer(Tail1)], Tail, State};
+      {[list_to_integer(Tail1, 16)], Tail, State};
     [$# | Tail1] -> %% dec number of char's code point
       case catch list_to_integer(Tail1) of
         {'EXIT', _} -> throw({error, "Malformed: Illegal character in reference"});

--- a/src/erlsom_write.erl
+++ b/src/erlsom_write.erl
@@ -606,7 +606,7 @@ processAnyNamespaces(Name, Uri, Namespaces, {NamespacesList, Counter} = Declared
       case lists:keysearch(Uri, #ns.uri, Namespaces) of
         {value, #ns{prefix = ModelPrefix}} ->
           ThePrefix = ModelPrefix;
-        _Else ->
+        _Else2 ->
           %% make up a prefix, using counter
           ThePrefix = "pre" ++ integer_to_list(Counter +1)
       end,

--- a/test/erlsom_tests.erl
+++ b/test/erlsom_tests.erl
@@ -6,7 +6,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--compile([export_all]).
+-compile([nowarn_export_all, export_all]).
 
 gexf_test_() ->
     {"Test XML/XSD in GEXF format.", {module, erlsom_gexf_tests}}.


### PR DESCRIPTION
- Use list_to_integer instead of deprecated httpd_util
- Fix unintended match in case statement
- Silence warning
