### PR TITLE
fix: Don't duplicate #text elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ include.mk
 .rebar
 .eunit
 .test
+_build/
+erlsom.plt
+rebar.lock

--- a/priv/extension/Makefile
+++ b/priv/extension/Makefile
@@ -1,0 +1,5 @@
+all: validate
+
+validate:
+	@xmllint --noout --schema extension.xsd extension.xml
+	@xmllint --noout --schema simpleContentExtension.xsd simpleContentExtension.xml

--- a/priv/extension/simpleContentExtension.xml
+++ b/priv/extension/simpleContentExtension.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test xmlns="http://my.uri" a="aaa" b="bbb">myuri</test>

--- a/priv/extension/simpleContentExtension.xsd
+++ b/priv/extension/simpleContentExtension.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://my.uri"
+	xmlns="http://my.uri"
+	xmlns:tns="http://my.uri"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	blockDefault="#all"
+	version="0.2">
+	<xsd:complexType name="AttributedString">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute name="a" type="xsd:string"/>
+				<xsd:anyAttribute namespace="##other" processContents="lax"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="EncodedString">
+		<xsd:simpleContent>
+			<xsd:extension base="tns:AttributedString">
+				<xsd:attribute name="b" type="xsd:string"/>
+				<xsd:attribute name="EncodingType" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="KeyIdentifierType">
+		<xsd:simpleContent>
+			<xsd:extension base="tns:EncodedString">
+				<xsd:attribute name="ValueType" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+    <xsd:element name="test" type="KeyIdentifierType"/>
+</xsd:schema>


### PR DESCRIPTION
The duplicate #text elements were generated in the case, when xsd:extension was used for xsd:simpleContent. That was causing the generated records being invalid. We solve this by filter the duplicate elements.