### PR TITLE
Accept charlist as output option for erlsom:write/3

### DIFF
--- a/src/erlsom_write.erl
+++ b/src/erlsom_write.erl
@@ -55,6 +55,8 @@ write(Struct, Model = #model{tps = Types}, Options) ->
           {ok, unicode:characters_to_list(ResultWithThisElement)};
         chardata ->
           {ok, ResultWithThisElement};
+        charlist ->
+          {ok, ResultWithThisElement};
         binary ->
           {ok, unicode:characters_to_binary(ResultWithThisElement)}
       end;


### PR DESCRIPTION
The reference documentation states that one can use `charlist` as output option for erlsom:write/3, but the code actually expected `chardata`. This change allows both `chardata` and `charlist` as output option which makes the documentation true while not breaking existing clients.