### PR TITLE
pass verify_none to httpc:request

### DIFF
--- a/src/erlsom_lib.erl
+++ b/src/erlsom_lib.erl
@@ -856,7 +856,8 @@ getFile(Location, IncludeDirs) ->
   end.
 
 httpGetFile(URL) ->
-  case httpc:request(get, {URL, [{"user-agent", "erlsom"}]}, [], []) of
+  HttpOptions = [{ssl, [{verify, verify_none}]}],
+  case httpc:request(get, {URL, [{"user-agent", "erlsom"}]}, HttpOptions, []) of
         {ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
             toUnicode(Body);
         {ok,{{_HTTP,RC,Emsg}, _Headers, _Body}} ->
@@ -924,7 +925,8 @@ prefix(Namespace) ->
 %%% slightly modified
 %%% --------------------------------------------------------------------
 get_url("http://"++_ = URL) ->
-  case httpc:request(URL) of
+  HttpOptions = [{ssl, [{verify, verify_none}]}],
+  case httpc:request(get, {URL, []}, HttpOptions, []) of
     {ok, {{_HTTP, 200, _OK}, _Headers, Body}} ->
       {ok, Body};
     _ ->


### PR DESCRIPTION
The `ssl` changes in OTP-26 mean that any code that doesn't specify `verify_none` will default to `verify_peer`, and unless certs are passed in you get hard errors. This also affects `httpc:request`. Update uses of the latter to explicitly pass in `verify_none`.