### PR TITLE
Fix sequence numbering in choice with sequences with complexTypes

### DIFF
--- a/priv/choice_complex/choice_complex.xml
+++ b/priv/choice_complex/choice_complex.xml
@@ -1,0 +1,5 @@
+<ns:L1 xmlns:ns="http://example.com">
+  <E_MAIL>
+    <TEXT>text</TEXT>
+  </E_MAIL>
+</ns:L1>

--- a/priv/choice_complex/choice_complex.xsd
+++ b/priv/choice_complex/choice_complex.xsd
@@ -1,0 +1,24 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   xmlns="http://example.com"
+	   targetNamespace="http://example.com" elementFormDefault="unqualified"
+	   attributeFormDefault="unqualified">
+  <xs:element name="L1">
+    <xs:complexType>
+      <xs:choice>	
+	<xs:sequence>
+	  <xs:element name="E_MAIL" minOccurs="0" maxOccurs="unbounded">
+	    <xs:complexType>
+	      <xs:sequence>
+		<xs:element name="TEXT" type="xs:string" />
+	      </xs:sequence>
+	    </xs:complexType>
+	  </xs:element>
+	</xs:sequence>
+
+	<xs:sequence>
+          <xs:element name="FLAG" type="xs:boolean" fixed="true" minOccurs="0" />
+	</xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/erlsom_compile.erl
+++ b/src/erlsom_compile.erl
@@ -784,24 +784,21 @@ isAny(#alt{tag = '#any', anyInfo = #anyInfo{prCont = "lax", ns = "##any"}}) ->
 isAny(_) ->
   false.
 
-%% TODO: seqCnt should be passed from one element to the next, but not down into the
-%% tree (it should be reset to 0) (the first sequence-in-sequnce should always have nr. 1).
-%% -record(localElementType, {name, type, ref, minOccurs, maxOccurs, simpleOrComplex}).
 translateSequence([LocalElement = #localElementType{} |Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateLocalElement(LocalElement, Acc),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
+  {Element, Acc2} = translateLocalElement(LocalElement, Acc#p1acc{seqCnt = 0}),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 translateSequence([ChoiceElement = #choiceType{} |Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateElement(ChoiceElement, Acc),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
+  {Element, Acc2} = translateElement(ChoiceElement, Acc#p1acc{seqCnt = 0}),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 translateSequence([AnyElement = #anyType{} |Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateElement(AnyElement, Acc),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
+  {Element, Acc2} = translateElement(AnyElement, Acc#p1acc{seqCnt = 0}),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 translateSequence([GroupElement = #groupRefType{} |Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateElement(GroupElement, Acc),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
+  {Element, Acc2} = translateElement(GroupElement, Acc#p1acc{seqCnt = 0}),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 translateSequence([SequenceElement = #sequenceType{} | Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateSequenceInSequence(SequenceElement, Acc),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
+  {Element, Acc2} = translateSequenceInSequence(SequenceElement, Acc#p1acc{seqCnt = 0}),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 
 translateSequence(undefined, ElementsSoFar, Acc) ->
   {lists:reverse(ElementsSoFar), Acc};

--- a/src/erlsom_compile.erl
+++ b/src/erlsom_compile.erl
@@ -797,8 +797,8 @@ translateSequence([GroupElement = #groupRefType{} |Tail], ElementsSoFar, Acc) ->
   {Element, Acc2} = translateElement(GroupElement, Acc#p1acc{seqCnt = 0}),
   translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
 translateSequence([SequenceElement = #sequenceType{} | Tail], ElementsSoFar, Acc) ->
-  {Element, Acc2} = translateSequenceInSequence(SequenceElement, Acc#p1acc{seqCnt = 0}),
-  translateSequence(Tail, [Element | ElementsSoFar], Acc2#p1acc{seqCnt = Acc#p1acc.seqCnt});
+  {Element, Acc2} = translateSequenceInSequence(SequenceElement, Acc),
+  translateSequence(Tail, [Element | ElementsSoFar], Acc2);
 
 translateSequence(undefined, ElementsSoFar, Acc) ->
   {lists:reverse(ElementsSoFar), Acc};

--- a/test/erlsom_tests.erl
+++ b/test/erlsom_tests.erl
@@ -151,3 +151,9 @@ xsi_type_no_prefix_read_test() ->
     ?assertMatch({'ExtType', _, "base", "ext"}, Parsed).
 
 
+choice_complex_test() ->
+    {ok, Xsd} = file:read_file(priv_path(["choice_complex", "choice_complex.xsd"])),
+    {ok, Xml} = file:read_file(priv_path(["choice_complex", "choice_complex.xml"])),
+    {ok, Model} = erlsom:compile(Xsd),
+    {ok, _Data, _} = erlsom:scan(Xml, Model).
+


### PR DESCRIPTION
The sequence numbering was reset within the complexType handling and this change attempts to preserve the sequence numbering across the elements in the choice alternative handling.

Hi @willemdj  this PR fixes #96 and all tests passes, including the new one I added.

First I fixed it by reverting this change https://github.com/willemdj/erlsom/commit/42dc8c9a41b68b50307b49f1b3637f97ca3c0125#diff-9669fbc4324a63d6d211486aeef2f42b2fb749159b449a5f2aae44ab5c9f0930R520 so translateLocalComplexType/2 wouldn't reset the seqCnt - @devinus do you know why this change was introduced? With the seqCnt reset removed all tests still pass.

In any case I came across the TODO (removed in the commit) and it made sense to me and I changed the code to preserve the count across elements and reset it when recursing.

What do you think?

Kind regards,
Lars